### PR TITLE
ci: use Ubuntu Trusty instead of Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,7 @@
-language: java
+language: groovy
 jdk: oraclejdk8
-# travis' 'oraclejdk8' is too old to compile the sources (JDK 8u31)
-# this is a workaround
-# see https://github.com/travis-ci/travis-ci/issues/3259
+dist: trusty
 sudo: false
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
 
 # don't upload the gradle caches
 before_cache:


### PR DESCRIPTION
Ubuntu Trusty already comes with the latest oracle jdk so we don't need to install it ourself